### PR TITLE
Changing default branch to develop

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -80,7 +80,7 @@ jobs:
                   python -m build
 
             - name: Download artifact
-              uses: actions/download-artifact@v5
+              uses: actions/download-artifact@v6
               with:
                   path: dist
                   merge-multiple: true


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump actions/download-artifact in the PyPI package workflow from v5 to v6.